### PR TITLE
Voltage daq disconnect fix

### DIFF
--- a/digilent-mcc118-pressure.py
+++ b/digilent-mcc118-pressure.py
@@ -108,6 +108,8 @@ def main():
     try:
         address = select_hat_device(HatIDs.MCC_118)
         hat = mcc118(address)
+        # Save the correct mask for channels [4,5,6,7] so restarts use it too
+        hat.channel_mask = channel_mask
         input('\nPress ENTER to continue ...')
         start_acquisition(hat, channel_mask, 0, scan_rate, options)
         logging.info("DAQ acquisition started. Press Ctrl-C to stop.")
@@ -152,7 +154,7 @@ def read_and_display_data(hat, num_channels, csv_handle, db_cloud, table_name, r
             if read_result.buffer_overrun:
                 logging.warning("Buffer overrun detected. Restarting acquisition.")
                 stop_and_cleanup(hat)
-                start_acquisition(hat, chan_list_to_mask(range(num_channels)), 0, 1000.0, OptionFlags.CONTINUOUS)
+                start_acquisition(hat, hat.channel_mask, 0, 1000.0, OptionFlags.CONTINUOUS)
                 continue
 
             new_samples = np.array(read_result.data).reshape(-1, num_channels)

--- a/digilent-mcc128-pressure.py
+++ b/digilent-mcc128-pressure.py
@@ -110,6 +110,8 @@ def main():
         hat = mcc128(address)
         hat.a_in_mode_write(input_mode)
         hat.a_in_range_write(input_range)
+        # save the correct mask for later restarts
+        hat.channel_mask = channel_mask
         input('\nPress ENTER to continue ...')
         start_acquisition(hat, channel_mask, 0, scan_rate, options)
         logging.info("DAQ acquisition started. Press Ctrl-C to stop.")
@@ -154,7 +156,8 @@ def read_and_display_data(hat, num_channels, csv_handle, db_cloud, table_name, r
             if read_result.buffer_overrun:
                 logging.warning("Buffer overrun detected. Restarting acquisition.")
                 stop_and_cleanup(hat)
-                start_acquisition(hat, chan_list_to_mask(range(num_channels)), 0, 1000.0, OptionFlags.CONTINUOUS)
+                # reuse the original mask we saved on hat
+                start_acquisition(hat, hat.channel_mask, 0, 1000.0, OptionFlags.CONTINUOUS)
                 continue
 
             new_samples = np.array(read_result.data).reshape(-1, num_channels)


### PR DESCRIPTION
Restarts previously used range(num_channels) to rebuild the channel mask, which ignored the actual channels list. This caused restarts to scan the wrong inputs, likely causing the mysterious voltage DAQ disconnects when a buffer overflow occurred.

This update:

- Saves the original channel_mask during initialization.
- Reuses it for all acquisition restarts.
- Applies the same pattern to the MCC 128 script for future-proofing, in case the channel list is changed later.